### PR TITLE
Update CKB release prefix to v0.209

### DIFF
--- a/sync.ps1
+++ b/sync.ps1
@@ -13,7 +13,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-$CkbReleasePattern = "v0.208*"
+$CkbReleasePattern = "v0.209*"
 $MainnetAssumeValidTarget = ""
 $TestnetAssumeValidTarget = ""
 

--- a/sync.sh
+++ b/sync.sh
@@ -18,7 +18,7 @@ if [[ "$RESTART_FLAG" != "0" && "$RESTART_FLAG" != "1" ]]; then
 fi
 
 # 0x0000000000000000000000000000000000000000000000000000000000000000
-ckb_version_prefix="v0.208"
+ckb_version_prefix="v0.209"
 mainnet_assume_valid_target=""
 testnet_assume_valid_target=""
 


### PR DESCRIPTION
## What changed

- Update the Ubuntu sync script to select the latest `v0.209.x` CKB release.
- Update the Windows sync script to select the latest `v0.209.x` CKB release.

## Why

CKB `v0.209.0` is now available, so both supported synchronization environments should use the 0.209 release line.

## Impact

The next fresh sync run on Ubuntu or Windows will download the latest matching `v0.209.x` release.

## Validation

- `bash -n sync.sh`
- `git diff --check`
- Confirmed the official `v0.209.0` release contains the expected Linux and Windows assets
- PowerShell parser validation was not run because `pwsh` is not installed locally
